### PR TITLE
Added growth of baby animals when crouching and hold sneak to continuous crop growth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-version = '1.3.9'
+version = '1.4.1'
 group = 'com.ticticbooom.twerkitmeal' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'TwerkItMeal'
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-version = '1.3.8'
+version = '1.3.9'
 group = 'com.ticticbooom.twerkitmeal' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'TwerkItMeal'
 

--- a/src/main/java/com/ticticboooom/twerkitmeal/TwerkItMeal.java
+++ b/src/main/java/com/ticticboooom/twerkitmeal/TwerkItMeal.java
@@ -5,6 +5,8 @@ import com.ticticboooom.twerkitmeal.config.TwerkConfig;
 import com.ticticboooom.twerkitmeal.dynamictrees.DTProxy;
 import com.ticticboooom.twerkitmeal.helper.FilterListHelper;
 import net.minecraft.block.*;
+import net.minecraft.entity.AgeableEntity;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.item.BoneMealItem;
@@ -13,6 +15,7 @@ import net.minecraft.item.Items;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.particles.ParticleTypes;
 import net.minecraft.tags.BlockTags;
+import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
@@ -25,6 +28,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import org.apache.commons.lang3.tuple.Pair;
 
+import javax.annotation.Nullable;
 import java.util.*;
 
 
@@ -100,6 +104,7 @@ public class TwerkItMeal {
             crouchCount.put(uuid, 0);
             List<BlockPos> growables = getNearestBlocks(event.player.world, event.player.getPosition());
             Set<BlockPos> grownDT = new HashSet<>();
+
             for (BlockPos growablePos : growables) {
                 BlockState blockState = event.player.world.getBlockState(growablePos);
                 if (!FilterListHelper.shouldAllow(blockState.getBlock().getRegistryName().toString())) {
@@ -119,14 +124,25 @@ public class TwerkItMeal {
                 } else if (DTProxy.getProxy().blockAllowed(blockState.getBlock())) {
                     DTProxy.getProxy().grow(event.player.world, growablePos, grownDT);
                 }
-                ((ServerWorld)event.player.world).spawnParticle((ServerPlayerEntity) event.player, ParticleTypes.HAPPY_VILLAGER, false, growablePos.getX() + event.player.world.rand.nextDouble(), growablePos.getY() + event.player.world.rand.nextDouble(), growablePos.getZ() + event.player.world.rand.nextDouble(), 10, 0, 0, 0, 3);
+                SpawnParticles(event.player, growablePos);
+            }
+
+            if (!TwerkConfig.growBabies) return;
+
+            List<AgeableEntity> entities = getNearestAgeableEntities(event.player.world, event.player.getPosition());
+
+            for (AgeableEntity entity:
+                    entities) {
+                entity.addGrowth(8000 / 20);
+
+                SpawnParticles(event.player, entity.getPosition());
             }
         }
 
         private List<BlockPos> getNearestBlocks(World world, BlockPos pos) {
             List<BlockPos> list = new ArrayList<>();
             for (int x = -TwerkConfig.effectRadius; x <= TwerkConfig.effectRadius; x++)
-                for (int y = -2; y <= 2; y++)
+                for (int y = -TwerkConfig.effectRadius; y <= TwerkConfig.effectRadius; y++)
                     for (int z = -TwerkConfig.effectRadius; z <= TwerkConfig.effectRadius; z++) {
                         Block block = world.getBlockState(new BlockPos(x + pos.getX(), y + pos.getY(), z + pos.getZ())).getBlock();
                         if (block instanceof IGrowable || DTProxy.getProxy().blockAllowed(block)) {
@@ -136,6 +152,46 @@ public class TwerkItMeal {
                         }
                     }
             return list;
+        }
+
+        private List<AgeableEntity> getNearestAgeableEntities(World world, BlockPos pos) {
+            List<AgeableEntity> list = new ArrayList<>();
+
+            for (int x = -TwerkConfig.effectRadius; x <= TwerkConfig.effectRadius; x++)
+                for (int y = -2; y <= 2; y++)
+                    for (int z = -TwerkConfig.effectRadius; z <= TwerkConfig.effectRadius; z++) {
+                        List<AgeableEntity> posEntitiesList =
+                                world.getEntitiesWithinAABB(
+                                        AgeableEntity.class,
+                                        new AxisAlignedBB(
+                                                new BlockPos(
+                                                        x + pos.getX(),
+                                                        y + pos.getY(),
+                                                        z + pos.getZ()
+                                                )
+                                        )
+                                );
+                        for (AgeableEntity entity :
+                             posEntitiesList) {
+                            if (entity.getGrowingAge() < 0) {
+                                list.add(entity);
+                            }
+                        }
+                    }
+
+            return list;
+        }
+
+        private void SpawnParticles(PlayerEntity player, BlockPos pos){
+            ((ServerWorld)player.world).spawnParticle(
+                    (ServerPlayerEntity) player,
+                    ParticleTypes.HAPPY_VILLAGER,
+                    false,
+                    pos.getX() + player.world.rand.nextDouble(),
+                    pos.getY() + player.world.rand.nextDouble(),
+                    pos.getZ() + player.world.rand.nextDouble(),
+                    10, 0, 0, 0, 3
+            );
         }
 
         private CompoundNBT createCompoundTag(BlockPos pos) {

--- a/src/main/java/com/ticticboooom/twerkitmeal/TwerkItMeal.java
+++ b/src/main/java/com/ticticboooom/twerkitmeal/TwerkItMeal.java
@@ -53,6 +53,7 @@ public class TwerkItMeal {
         private final Map<UUID, Integer> crouchCount = new HashMap<>();
         private final Map<UUID, Boolean> prevSneaking = new HashMap<>();
         private final Map<UUID, Integer> playerDistance = new HashMap<>();
+        private final Map<UUID, Integer> playerHoldTimer = new HashMap<>();
 
         @SubscribeEvent
         public void onTwerk(TickEvent.PlayerTickEvent event) {
@@ -69,6 +70,10 @@ public class TwerkItMeal {
             ServerWorld world = (ServerWorld) event.player.world;
 
             if (event.player.isSprinting() && world.getRandom().nextDouble() <= TwerkConfig.sprintGrowChance){
+                triggerGrowth(event, uuid);
+            }
+
+            if (event.player.isSneaking()){
                 triggerGrowth(event, uuid);
             }
 

--- a/src/main/java/com/ticticboooom/twerkitmeal/config/CommonConfig.java
+++ b/src/main/java/com/ticticboooom/twerkitmeal/config/CommonConfig.java
@@ -15,6 +15,7 @@ public class CommonConfig {
     public final ForgeConfigSpec.BooleanValue saplingsOnly;
     public final ForgeConfigSpec.DoubleValue sprintGrowChance;
     public final ForgeConfigSpec.DoubleValue crouchGrowChance;
+    public final ForgeConfigSpec.BooleanValue growBabies;
 
     public CommonConfig(ForgeConfigSpec.Builder builder) {
         List<String> defaultBlackList = new ArrayList<>();
@@ -44,5 +45,7 @@ public class CommonConfig {
                 .defineInRange("sprintGrowChance", 0.15, 0, 1);
         crouchGrowChance = builder.comment("The chance of growth effect being applied from any source")
                 .defineInRange("crouchGrowChance", 0.5, 0, 1);
+        growBabies = builder.comment("Whether to grow up baby animals, villagers and other ageable mobs or not when twerking")
+                .define("growBabies", true);
     }
 }

--- a/src/main/java/com/ticticboooom/twerkitmeal/config/TwerkConfig.java
+++ b/src/main/java/com/ticticboooom/twerkitmeal/config/TwerkConfig.java
@@ -16,6 +16,7 @@ public class TwerkConfig {
     public static int distanceSprintedToGrow;
     public static double sprintGrowChance;
     public static double crouchGrowChance;
+    public static boolean growBabies;
 
     public static void bake(ModConfig config) {
         showParticles = TwerkItMeal.COMMON_CONFIG.showParticles.get();
@@ -27,5 +28,6 @@ public class TwerkConfig {
         saplingsOnly = TwerkItMeal.COMMON_CONFIG.saplingsOnly.get();
         sprintGrowChance = TwerkItMeal.COMMON_CONFIG.sprintGrowChance.get();
         crouchGrowChance = TwerkItMeal.COMMON_CONFIG.crouchGrowChance.get();
+        growBabies = TwerkItMeal.COMMON_CONFIG.growBabies.get();
     }
 }


### PR DESCRIPTION
- Added the ability so when players sneak around baby animals, accelerate/bonemeal their growth.
- Added hold-crouch feature for 1.16.5

TODO: 
- Add Config to hold-crouch method
- Add hold-crouch timer before starting bonemeal

BUGS:
- Sugarcane wont get re-bonemealed when holding crouch. Player needs to repeatly press and release crouch key to grow sugarcane. Possible issue with mods tweaking sugarcane height grow limit.